### PR TITLE
Setting the whitespace option to true doesn't have any effect, the whitespaces are not preserved.

### DIFF
--- a/tasks/grunt-dust-html.js
+++ b/tasks/grunt-dust-html.js
@@ -61,18 +61,18 @@ module.exports = function(grunt) {
         var context = opts.context;
         var tmpl;
 
+        // preserve whitespace?
+        if(opts.whitespace) {
+            dust.optimizers.format = function(ctx, node) {
+                return node;
+            };
+        }
+
         // pre-compile the template
         try {
           tmpl = dust.compileFn(grunt.file.read(srcFile));
         } catch(err) {
           parseError(err, srcFile);
-        }
-
-        // preserve whitespace?
-        if(opts.whitespace) {
-          dust.optimizers.format = function(ctx, node) {
-            return node;
-          };
         }
 
         // if context is a string assume it's the location to a file


### PR DESCRIPTION
We want to generate our templates and preserve the whitespaces in them. In order to do that we specified the whitespace option in the Gruntfile.js. It seems like the setting doesn't have any effect if the dust.optimizers.format isn't set before the compilation takes place. I have changed grunt-dust-html.js and moved the setting up a few lines before the compile step.

From the dust-linkedin api: 
"Object containing functions that transform the parse-tree before the template is compiled. To disable whitespace compression:
    dust.optimizers.format = function(ctx, node) { return node };"

From our Gruntfile.js:
  dusthtml: {
    dist: {
      src: "src/home.dust",
      dest: "dist/home.html",
      options: {
        whitespace:true
      }
    }
}
