### PR TITLE
Add dustjs-helpers dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies" : {
     "dustjs-linkedin": "~2.2.2",
+    "dustjs-helpers": "~1.1.2",
     "async":"~0.2.9",
     "lodash":"~2.4.1"
   },


### PR DESCRIPTION
Required `dustjs-helpers` dependency seems to be missing from `package.json`.
