### PR TITLE
adding possibility to enter multiple "basePath" with Array.

### DIFF
--- a/tasks/grunt-dust-html.js
+++ b/tasks/grunt-dust-html.js
@@ -74,6 +74,10 @@ module.exports = function(grunt) {
       f.src.forEach(function(srcFile) {
         var context = opts.context;
         var tmpl;
+        var filePath = path.dirname(srcFile);
+        var fileExt = path.extname(srcFile);
+        var fileName = path.basename(srcFile, fileExt);
+        var fileContext = path.join(filePath, fileName + '.json');
 
         // preserve whitespace?
         if(opts.whitespace) {
@@ -104,6 +108,10 @@ module.exports = function(grunt) {
 
             _.extend(context, obj);
           });
+        }
+
+        if(grunt.file.isFile(fileContext)){
+          _.extend(context, grunt.file.readJSON(fileContext));
         }
 
         // render template and save as html


### PR DESCRIPTION
This option allows you to reduce the search path in the archives. 

Directory structure: 

```
app
|-- brands
|   |-- myBrand
|   |   `-- index.dust
|   `-- otherBrand
|       |-- index.dust
|       `-- layouts
|           `-- base.dust
|-- index.dust
`-- layouts
    `-- base.dust
```

And Grunt config:

```
    dusthtml:{
      myBrand: {
        options: {
          basePath: ['app/brands/myBrand/', 'app/']
        },
        files: ['app/brands/myBrand/index.dust']
      },
      otherBrand: {
        options: {
          basePath: ['app/brands/otherBrand/', 'app/']
        },
        files: ['app/brands/otherBrand/index.dust']
      }
    }
```

Say `app/brands/myBrand/index.dust` and `app/brands/otherBrand/index.dust` contains:

```
{>"layouts/base"}
{<body}my body block{/body}
```

So `app/brands/myBrand/index.dust` read the file `app/layouts/base.dust` and `app/brands/otherBrand/index.dust` read `app/brands/otherBrand/layouts/base.dust`
