### PR TITLE
add option to disable dust template cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
         options: {
           partialsDir: 'src/',
           whitespace: true,
+          cache: true,
           context: {
             title: 'Home Page',
             header: 'Header text',

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test": "grunt"
   },
   "dependencies": {
-    "dustjs-linkedin": "~2.5.1",
-    "dustjs-helpers": "~1.5.0",
+    "dustjs-linkedin": "~2.7.0",
+    "dustjs-helpers": "~1.7.0",
     "lodash": "~2.4.1",
     "bluebird": "~2.4.0"
   },

--- a/tasks/lib/dusthtml.js
+++ b/tasks/lib/dusthtml.js
@@ -16,6 +16,7 @@ module.exports.render = function(input, opts, callback) {
     partialsDir: '.',
     defaultExt: '.dust',
     whitespace: false,
+    cache: true,
     module: 'dustjs-linkedin', // dust, dustjs-helpers, or dustjs-linkedin
     context: {}
   }, opts || {});
@@ -64,6 +65,10 @@ module.exports.render = function(input, opts, callback) {
       return node;
     };
   }
+
+  // turn off dust caching templates and partials.
+  // caching should be turned off if you want use grunt-dust-html with watchers
+  dust.config.cache = opts.cache;
 
   // Pre-compile the template
   try {


### PR DESCRIPTION
We use grunt-dust-html with grunt watchers. Every time we change our *.dust-Templates, grunt-dust-html should generate new html files. The problem here is, that dustjs loaded the partias and templates in a cache. So we cant see the updated versions. 
With the new option cache (Boolean, default:  true) you are able to turn off the cachine mechanism from dustjs. 
