### PR TITLE
Fix error with using {.}

### DIFF
--- a/tasks/lib/dusthtml.js
+++ b/tasks/lib/dusthtml.js
@@ -83,6 +83,7 @@ module.exports.render = function(input, opts, callback) {
 
   // If context is an array merge each item together
   } else if(Array.isArray(opts.context)) {
+    context = {};
     opts.context.forEach(function(obj) {
       if(typeof obj === 'string') {
         obj = grunt.file.readJSON(obj);


### PR DESCRIPTION
I was using version 0.1.6 and in my code, I use `{.|js|s}` to store the dust context. This fails in version 0.3.0 when my opt.context is an array of string JSON files. This line was removed for some reason, but it should be added back for people who use `{.}` in their code.
